### PR TITLE
Enhancements around signing uploads

### DIFF
--- a/lib/guss/canonical.ex
+++ b/lib/guss/canonical.ex
@@ -1,7 +1,6 @@
 defmodule Guss.Canonical do
-  @moduledoc """
-  Conveniences for converting `Guss.Resource` components into canonical iodata.
-  """
+  @moduledoc false
+
   alias __MODULE__
   alias Guss.Resource
 

--- a/lib/guss/canonical.extensions.ex
+++ b/lib/guss/canonical.extensions.ex
@@ -1,21 +1,11 @@
 defmodule Guss.Canonical.Extensions do
-  @moduledoc """
-  Generates iodata for Canonicalized Extension Headers
-
-  Extension headers are generated using the following algorithm:
-
-  1. Make all custom header names lowercase.
-  2. Sort all custom headers by header name using a lexicographical sort by code point value.
-  3. If present, remove the `x-goog-encryption-key` and `x-goog-encryption-key-sha256` headers. These headers contain sensitive information that must not be included in the string-to-sign; however, these headers must still be used in any requests that use the generated signed URL.
-  4. Eliminate duplicate header names by creating one header name with a comma-separated list of values. Be sure there is no whitespace between the values, and be sure that the order of the comma-separated list matches the order that the headers appear in your request. For more information, see [RFC 7230 section 3.2](https://tools.ietf.org/html/rfc7230#section-3.2).
-  5. Replace any folding whitespace or newlines (CRLF or LF) with a single space. For more information about folding whitespace, see [RFC 7230, section 3.2.4](https://tools.ietf.org/html/rfc7230#section-3.2.4).
-  6. Remove any whitespace around the colon that appears after the header name.
-  7. Append a newline `\\n` (U+000A) to each custom header.
-  8. Concatenate all custom headers.
-  """
+  @moduledoc false
 
   @doc """
   Converts resource extensions into canonical extension headers.
+
+  For more information, see:
+  https://cloud.google.com/storage/docs/access-control/signed-urls-v2
 
   ## Examples
 

--- a/lib/guss/request_headers.ex
+++ b/lib/guss/request_headers.ex
@@ -7,7 +7,7 @@ defmodule Guss.RequestHeaders do
   Convert the enumerable to a dasherized list, suitable for URL signing.
 
   The enumerable will have the following transformations applied:
-  * Header keys are lower-cased.
+  * Header keys are downcased.
   * Underscores (`"_"`) are replaced with dashes (`"-"`).
   * Leading and trailing whitespace is removed.
   * Keys with empty values will be removed.
@@ -117,11 +117,11 @@ defmodule Guss.RequestHeaders do
 
   ## Examples
 
-    iex> Guss.RequestHeaders.deduplicate([{"x", "foo"}, {"x", "bar"}])
-    [{"x", "foo,bar"}]
+      iex> Guss.RequestHeaders.deduplicate([{"x", "Foo"}, {"x", "Bar"}])
+      [{"x", "Foo,Bar"}]
 
-    iex> Guss.RequestHeaders.deduplicate([{"x", "this"}, {"bar", "qux"}, {"x", "that"}])
-    [{"bar", "qux"}, {"x", "this,that"}]
+      iex> Guss.RequestHeaders.deduplicate([{"x", "this"}, {"bar", "qux"}, {"x", "that"}])
+      [{"bar", "qux"}, {"x", "this,that"}]
   """
   def deduplicate(enumerable) do
     for {k, v} <- Enum.group_by(enumerable, &elem(&1, 0), &elem(&1, 1)) do

--- a/lib/guss/request_headers.ex
+++ b/lib/guss/request_headers.ex
@@ -1,6 +1,12 @@
 defmodule Guss.RequestHeaders do
   @moduledoc """
   Conveniences for working with canonical request headers.
+
+  Normally you do not need to access this module directly. It is
+  meant to be used by the signing processes.
+
+  If you want to get a list of signed headers for your request,
+  see `Guss.Resource.signed_headers/1`.
   """
 
   @doc """

--- a/lib/guss/request_headers.ex
+++ b/lib/guss/request_headers.ex
@@ -1,0 +1,137 @@
+defmodule Guss.RequestHeaders do
+  @moduledoc """
+  Conveniences for working with canonical request headers.
+  """
+
+  @doc """
+  Convert the enumerable to a dasherized list, suitable for URL signing.
+
+  The enumerable will have the following transformations applied:
+  * Header keys are lower-cased.
+  * Underscores (`"_"`) are replaced with dashes (`"-"`).
+  * Leading and trailing whitespace is removed.
+  * Keys with empty values will be removed.
+  * Atom values will be dasherized like header keys. This is useful for some built-in values,
+    like `:public_read`.
+  * Integer values are converted to strings.
+  * Enumerable values will be expanded following the same transformation rules. See the examples
+    for more details.
+
+  The result is a list of `{key, value}` tuples for each request header, sorted by key name.
+
+  ## Examples
+
+      iex> Guss.RequestHeaders.dasherize(x_foo_bar: "qux")
+      [{"x-foo-bar", "qux"}]
+
+      iex> Guss.RequestHeaders.dasherize(x: [foo_bar: "qux"])
+      [{"x-foo-bar", "qux"}]
+
+      iex> Guss.RequestHeaders.dasherize(x: [foo: [bar: "qux"]])
+      [{"x-foo-bar", "qux"}]
+
+      ies> Guss.RequestHeaders.dasherize(x: [meta: [int: 42, atom: :foo_bar]])
+      [{"x-meta-int", "42"}, {"x-meta-atom", "foo-bar"}]
+
+      iex> Guss.RequestHeaders.dasherize(content_type: "text/plain", content_md5: "3a0ef89...")
+      [{"content-md5", "3a0ef89..."}, {"content-type", "text/plain"}]
+
+      iex> Guss.RequestHeaders.dasherize(X: [{:user, "Bob"}, {"User", "Alice"}])
+      [{"x-user", "Bob"}, {"x-user", "Alice"}]
+
+      iex> Guss.RequestHeaders.dasherize(x: [vendor: [id: "guss"], goog: [acl: :public_read]])
+      [{"x-goog-acl", "public-read"}, {"x-vendor-id", "guss"}]
+
+      iex> Guss.RequestHeaders.dasherize(%{"X" => %{"Goog" => %{"Acl" => "public-read", "Meta" => %{"Value" => 1}}}})
+      [{"x-goog-acl", "public-read"}, {"x-goog-meta-value", "1"}]
+
+      iex> Guss.RequestHeaders.dasherize(%{"X" => %{"Goog" => %{"Meta" => %{"  Value  " => 1}}}})
+      [{"x-goog-meta-value", "1"}]
+  """
+  def dasherize(data) when is_map(data) and data == %{}, do: []
+  def dasherize(data) when is_map(data), do: data |> Enum.into([]) |> do_dasherize()
+  def dasherize(data) when is_list(data), do: data |> do_dasherize()
+
+  # Starts collapsing items. Empty lists are ignored.
+  defp do_dasherize([]), do: []
+  defp do_dasherize(enum), do: dasherize_items(enum, [])
+
+  # Input values exhausted
+  defp dasherize_items([], acc), do: acc |> ordered_sort()
+
+  # Expands nested values
+  defp dasherize_items([{key, val} | rest], acc) when is_list(val) or is_map(val) do
+    dasherize_items(rest, dasherize_nested(key_name(key), val, acc))
+  end
+
+  # Ignores empty values
+  defp dasherize_items([{_, val} | rest], acc) when is_nil(val) or val == "" do
+    dasherize_items(rest, acc)
+  end
+
+  # Dasherizes atom values
+  defp dasherize_items([{key, val} | rest], acc) when is_atom(val) do
+    dasherize_items(rest, [{key_name(key), to_dashed(val)} | acc])
+  end
+
+  # Dasherizes key and stringifies values
+  defp dasherize_items([{key, val} | rest], acc) do
+    dasherize_items(rest, [{key_name(key), to_string(val)} | acc])
+  end
+
+  defp dasherize_nested(prefix, enum, acc) do
+    Enum.reduce(enum, acc, fn {key, val}, acc ->
+      next_key = "#{prefix}-#{key_name(key)}"
+
+      case val do
+        val when is_map(val) -> dasherize_nested(next_key, Enum.into(val, []), acc)
+        val when is_list(val) -> dasherize_nested(next_key, val, acc)
+        val when is_atom(val) -> [{next_key, to_dashed(val)} | acc]
+        val -> [{next_key, to_string(val)} | acc]
+      end
+    end)
+  end
+
+  defp to_dashed(str) when is_atom(str), do: to_dashed(Atom.to_string(str))
+  defp to_dashed(str) when is_binary(str), do: String.replace(str, "_", "-")
+
+  defp key_name(key), do: key |> to_dashed() |> String.trim() |> String.downcase()
+
+  defp ordered_sort(items) do
+    items
+    |> Enum.reverse()
+    |> Enum.with_index()
+    |> Enum.sort_by(fn {{k, _v}, i} -> {k, i} end)
+    |> Enum.unzip()
+    |> elem(0)
+  end
+
+  @doc """
+  Eliminates duplicate keys in the enumerable.
+
+  Duplicate keys will be replaced with a single key and a
+  comma-separated list of values.
+
+  The result is a list sorted alphabetically by key. Values will
+  retain their ordering in the original list.
+
+  ## Examples
+
+    iex> Guss.RequestHeaders.deduplicate([{"x", "foo"}, {"x", "bar"}])
+    [{"x", "foo,bar"}]
+
+    iex> Guss.RequestHeaders.deduplicate([{"x", "this"}, {"bar", "qux"}, {"x", "that"}])
+    [{"bar", "qux"}, {"x", "this,that"}]
+  """
+  def deduplicate(enumerable) do
+    for {k, v} <- Enum.group_by(enumerable, &elem(&1, 0), &elem(&1, 1)) do
+      {k, join_values(v, ",")}
+    end
+    |> Enum.into([])
+    |> Enum.sort_by(&elem(&1, 0))
+  end
+
+  defp join_values(items, joiner) when is_list(items) do
+    items |> Enum.map_join(joiner, &String.trim/1)
+  end
+end

--- a/lib/guss/resource.ex
+++ b/lib/guss/resource.ex
@@ -74,6 +74,33 @@ defmodule Guss.Resource do
             http_verb: :get,
             objectname: nil
 
+  @doc """
+  Get a list of canonical headers for the given resource.
+
+  This function returns a list of tuples for all headers defined
+  on a `Guss.Resource`. The list maintains the ordering of custom
+  extensions. To ensure full compatibility, the request using the
+  Signed URL should apply the signed headers in the order returned.
+
+  For more information, see `Guss.CanonicalData`.
+
+  ## Examples
+
+      iex> Guss.put("b", "o.txt")
+      ...> |> Guss.Resource.signed_headers()
+      []
+
+      iex> Guss.Resource.signed_headers(Guss.put("b", "o.txt", content_type: "text/plain"))
+      [{"content-type", "text/plain"}]
+  """
+  def signed_headers(%__MODULE__{} = resource) do
+    Guss.RequestHeaders.dasherize(
+      content_md5: resource.content_md5,
+      content_type: resource.content_type,
+      x_goog: resource.extensions
+    )
+  end
+
   defimpl List.Chars do
     import Guss.Canonical
 

--- a/lib/guss/signature.ex
+++ b/lib/guss/signature.ex
@@ -2,23 +2,20 @@ defmodule Guss.Signature do
   @moduledoc """
   Signs resources using RSA signatures with SHA256 to authenticate requests.
 
-  Signature was built to work with a `Guss.Resource`, but it will accept
-  any struct that implements `List.Chars`.
-
   For more information, see [Creating a Signed URL using a program](https://cloud.google.com/storage/docs/access-control/create-signed-urls-program).
   """
   @otp_greater_21? :erlang.system_info(:otp_release) >= '21'
 
   @doc """
-  Signs the resource iodata using a service account key.
+  Signs the data using a service account key.
 
-  The given resource may be a binary value or any data structure that
+  The given data may be binary or any data structure that
   implements the `List.Chars` protocol.
   """
   @spec generate(any(), binary()) :: {:error, {:signature, any()}} | {:ok, binary()}
-  def generate(resource, private_key) when is_binary(private_key) do
+  def generate(data, private_key) when is_binary(private_key) do
     try do
-      signature = generate!(resource, private_key)
+      signature = generate!(data, private_key)
 
       {:ok, signature}
     rescue
@@ -27,19 +24,19 @@ defmodule Guss.Signature do
   end
 
   @doc """
-  Signs the resource iodata using a service account key.
+  Signs the data using a service account key.
 
   Same as `generate/2`, but raises on error.
   """
-  @spec generate!(resource :: any(), private_key :: binary()) :: binary()
-  def generate!(resource, private_key) when not is_binary(resource) do
-    resource |> to_charlist() |> to_string() |> generate!(private_key)
+  @spec generate!(data :: any(), private_key :: binary()) :: binary()
+  def generate!(data, private_key) when not is_binary(data) do
+    data |> to_charlist() |> to_string() |> generate!(private_key)
   end
 
-  def generate!(resource, private_key) when is_binary(resource) and is_binary(private_key) do
+  def generate!(data, private_key) when is_binary(data) and is_binary(private_key) do
     decoded_key = decode_key!(private_key)
 
-    resource
+    data
     |> :public_key.sign(:sha256, decoded_key)
     |> Base.encode64()
   end

--- a/lib/guss/storage_v2_signer.ex
+++ b/lib/guss/storage_v2_signer.ex
@@ -1,0 +1,32 @@
+defmodule Guss.StorageV2Signer do
+  @moduledoc """
+  Signs a `Guss.Resource` using the V2 Signing Process.
+  """
+  alias Guss.Signature
+
+  @doc """
+  Sign a URL for the given `Guss.Resource` using the `private_key`.
+  """
+  @spec sign(resource :: Guss.Resource.t(), private_key :: binary()) :: {:ok, String.t()}
+  def sign(%Guss.Resource{} = resource, private_key) when is_binary(private_key) do
+    with {:ok, signature} <- Signature.generate(resource, private_key) do
+      signed_url = build_url(resource, signature)
+      {:ok, signed_url}
+    end
+  end
+
+  @spec build_url(Guss.Resource.t(), binary()) :: String.t()
+  def build_url(%Guss.Resource{} = resource, signature) when is_binary(signature) do
+    query = resource |> build_signed_query(signature) |> URI.encode_query()
+
+    Enum.join([to_string(resource), "?", query])
+  end
+
+  defp build_signed_query(%Guss.Resource{account: account, expires: expires}, signature) do
+    %{
+      "GoogleAccessId" => account,
+      "Expires" => expires,
+      "Signature" => signature
+    }
+  end
+end

--- a/lib/guss/storage_v2_signer.ex
+++ b/lib/guss/storage_v2_signer.ex
@@ -1,19 +1,83 @@
 defmodule Guss.StorageV2Signer do
   @moduledoc """
-  Signs a `Guss.Resource` using the V2 Signing Process.
+  Sign a `Guss.Resource` using the Cloud Storage V2 Signing Process for Service Accounts.
+
+  This module generates the _string to sign_ for a ` Guss.Resource`,
+  and signs it using the given `private_key`. The signature is then
+  added to the URL, along with any required query string parameters.
+
+  For more information, see:
+  [V2 Signing Process](https://cloud.google.com/storage/docs/access-control/signed-urls-v2).
   """
-  alias Guss.Signature
+  alias Guss.{Resource, RequestHeaders, Signature}
 
   @doc """
   Sign a URL for the given `Guss.Resource` using the `private_key`.
   """
   @spec sign(resource :: Guss.Resource.t(), private_key :: binary()) :: {:ok, String.t()}
-  def sign(%Guss.Resource{} = resource, private_key) when is_binary(private_key) do
-    with {:ok, signature} <- Signature.generate(resource, private_key) do
+  def sign(%Resource{} = resource, private_key) when is_binary(private_key) do
+    s2s = string_to_sign(resource)
+
+    with {:ok, signature} <- Signature.generate(s2s, private_key) do
       signed_url = build_url(resource, signature)
       {:ok, signed_url}
     end
   end
+
+  @doc """
+  Generates the _string to sign_ for a `Guss.Resource`.
+
+  The _string to sign_ is a canonical representation of
+  the request to be made with the Signed URL.
+  """
+  @spec string_to_sign(Guss.Resource.t()) :: String.t()
+  def string_to_sign(%Resource{} = resource) do
+    headers_to_sign =
+      resource
+      |> Resource.signed_headers()
+      |> headers_to_sign()
+
+    http_verb = http_verb(resource.http_verb)
+
+    resource_name = resource_name(resource)
+
+    content_md5 = if is_nil(resource.content_md5), do: "", else: resource.content_md5
+
+    content_type = if is_nil(resource.content_type), do: "", else: resource.content_type
+
+    [
+      http_verb,
+      content_md5,
+      content_type,
+      Integer.to_string(resource.expires),
+      headers_to_sign,
+      resource_name
+    ]
+    |> Enum.intersperse(?\n)
+    |> IO.iodata_to_binary()
+  end
+
+  defp resource_name(%{bucket: bucket, objectname: objectname}) do
+    [?/, bucket, ?/, objectname]
+  end
+
+  defp http_verb(method) when is_atom(method), do: http_verb(Atom.to_string(method))
+  defp http_verb(method) when is_binary(method), do: String.upcase(method)
+
+  defp headers_to_sign([]), do: []
+
+  defp headers_to_sign(headers) when is_list(headers) do
+    for {k, v} <- RequestHeaders.deduplicate(headers),
+        filter_extension({k, v}) do
+      [k, ?:, v]
+    end
+    |> Enum.intersperse(?\n)
+    |> List.wrap()
+  end
+
+  defp filter_extension({"x-goog-encryption" <> _rest, _}), do: false
+  defp filter_extension({"x-goog-" <> _rest, _}), do: true
+  defp filter_extension(_kv), do: false
 
   @spec build_url(Guss.Resource.t(), binary()) :: String.t()
   def build_url(%Guss.Resource{} = resource, signature) when is_binary(signature) do

--- a/lib/guss/storage_v2_signer.ex
+++ b/lib/guss/storage_v2_signer.ex
@@ -79,8 +79,7 @@ defmodule Guss.StorageV2Signer do
   defp filter_extension({"x-goog-" <> _rest, _}), do: true
   defp filter_extension(_kv), do: false
 
-  @spec build_url(Guss.Resource.t(), binary()) :: String.t()
-  def build_url(%Guss.Resource{} = resource, signature) when is_binary(signature) do
+  defp build_url(%Guss.Resource{} = resource, signature) when is_binary(signature) do
     query = resource |> build_signed_query(signature) |> URI.encode_query()
 
     Enum.join([to_string(resource), "?", query])

--- a/mix.exs
+++ b/mix.exs
@@ -43,10 +43,13 @@ defmodule Guss.MixProject do
       source_ref: "v#{@version}",
       source_url: github_link(),
       groups_for_modules: [
-        "iodata components": [
+        "request components": [
           Guss.Resource,
-          Guss.Canonical,
-          Guss.Canonical.Extensions
+          Guss.RequestHeaders
+        ],
+        signatures: [
+          Guss.StorageV2Signer,
+          Guss.Signature
         ]
       ]
     ]

--- a/test/guss/request_headers_test.exs
+++ b/test/guss/request_headers_test.exs
@@ -1,0 +1,24 @@
+defmodule Guss.RequestHeadersTest do
+  use ExUnit.Case
+  doctest Guss.RequestHeaders
+
+  describe "dasherize/1" do
+    test "is idempotent" do
+      opts = [
+        a_foo_bar: "qux",
+        a: [foo_qux: "one"],
+        content_type: "text/plain",
+        content_md5: "3a0ef89...",
+        b: [
+          maps: %{"foo" => "bar", "ints" => 8701},
+          atoms: :project_private,
+          integers: 42
+        ]
+      ]
+
+      expected = Guss.RequestHeaders.dasherize(opts)
+
+      assert Guss.RequestHeaders.dasherize(expected) == expected
+    end
+  end
+end

--- a/test/guss_test.exs
+++ b/test/guss_test.exs
@@ -126,7 +126,9 @@ defmodule GussTest do
       |> String.to_integer()
       |> assert_valid_expires(3600 * 2)
 
-      {:ok, expected_signature} = Guss.Signature.generate(url, private_key)
+      s2s = Guss.StorageV2Signer.string_to_sign(url)
+
+      {:ok, expected_signature} = Guss.Signature.generate(s2s, private_key)
 
       assert Map.get(query, "Signature", false)
       assert Map.get(query, "Signature", false) == expected_signature


### PR DESCRIPTION
## Get Signed Headers

Use `Guss.Resource.signed_headers/1` to get a list of headers that need to be on the request using the Signed URL.

Closes #7 

## String to Sign

Currently, the `string_to_sign` is generated through `Guss.Resource` implementing `List.Chars`, but that limits the struct to a single URL signing process.

This PR moves the responsibility for generating the string to sign into `Guss.StorageV2Signer`.  Currently this is the only signing process available, so it's not configurable, but this should be a good setup for future extensibility around signing algorithms.